### PR TITLE
fix experience.Name and experience.Description

### DIFF
--- a/API/Assets/Experiences/Experience.cs
+++ b/API/Assets/Experiences/Experience.cs
@@ -245,8 +245,8 @@ namespace RoSharp.API.Assets.Experiences
                 throw new ArgumentException($"Invalid universe ID '{UniverseId}'");
             }
             dynamic data = whyaretheresomanywrappers.data[0];
-            name = data.sourceName;
-            description = data.sourceDescription;
+            name = data.name;
+            description = data.description;
             created = data.created;
             lastUpdated = data.updated;
             uncopylocked = data.copyingAllowed;

--- a/API/Assets/Experiences/Experience.cs
+++ b/API/Assets/Experiences/Experience.cs
@@ -46,12 +46,26 @@ namespace RoSharp.API.Assets.Experiences
         /// </summary>
         public string Name => name;
 
+        private string? sourceName;
+
+        /// <summary>
+        /// Gets the source name of the experience.
+        /// </summary>
+        public string SourceName => sourceName;
+
         private string description;
 
         /// <summary>
         /// Gets the description of the experience.
         /// </summary>
         public string Description => description;
+
+        private string? sourceDescription;
+
+        /// <summary>
+        /// Gets the source description of the experience.
+        /// </summary>
+        public string? SourceDescription => sourceDescription;
 
         private ulong ownerId;
         private string ownerName;
@@ -246,7 +260,9 @@ namespace RoSharp.API.Assets.Experiences
             }
             dynamic data = whyaretheresomanywrappers.data[0];
             name = data.name;
+            sourceName = data.sourceName;
             description = data.description;
+            sourceDescription = data.sourceDescription;
             created = data.created;
             lastUpdated = data.updated;
             uncopylocked = data.copyingAllowed;


### PR DESCRIPTION
Seems that, at least in my testing .sourceName and .sourceDescription is always null, not sure if this is a recent change or not.

<img width="805" height="789" alt="2025-07-19-23-39-19304" src="https://github.com/user-attachments/assets/405072ab-6e57-4057-b844-c7e12ea28065" />
